### PR TITLE
Email szerviz javítva.

### DIFF
--- a/backend/config-service/src/main/resources/local-config/email-service-local.properties
+++ b/backend/config-service/src/main/resources/local-config/email-service-local.properties
@@ -5,19 +5,10 @@ server.port=8086
 eureka.client.serviceUrl.defaultZone=http://localhost:8761/eureka/
 eureka.client.healthcheck.enabled=true
 
-## GMAIL SMTP PROPERTIES ##
-spring.mail.host=smtp.gmail.com
-spring.mail.port=587
-spring.mail.username=malus.stch@gmail.com
-spring.mail.password=kockadeni12
-spring.mail.properties.mail.smtp.starttls.enable=true
-spring.mail.properties.mail.smtp.starttls.required=true
-spring.mail.properties.mail.smtp.auth=true
-
 ## MAILHOG PROPERTIES ##
-#spring.mail.host=mailhog
-#spring.mail.port=1025
-#spring.mail.properties.mail.smtp.auth=false
+spring.mail.host=localhost
+spring.mail.port=1025
+spring.mail.properties.mail.smtp.auth=false
 
 spring.mail.properties.mail.smtp.connectiontimeout=5000
 spring.mail.properties.mail.smtp.timeout=5000

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -44,6 +44,7 @@ services:
     networks:
       - studentTaskChecker
     ports:
+      - 1025:1025
       - 8025:8025
 
   mysql-database:


### PR DESCRIPTION
Működik, csak most már ha lokálba olyan funkciót tesztelünk ahol van email küldés akkor a mailhogot is el kell indítani a dockerben úgy ahogy a mysqlt, a  `1025:1025` és `8025:8025` portokat kell megnyitni.